### PR TITLE
chore(settings): drop apis_core.relations

### DIFF
--- a/apis_instance_nsvis/settings.py
+++ b/apis_instance_nsvis/settings.py
@@ -5,7 +5,6 @@ INSTALLED_APPS[INSTALLED_APPS.index("apis_ontology")] = "apis_instance_nsvis"
 INSTALLED_APPS += ["auditlog"]
 INSTALLED_APPS += ["apis_core.history"]
 INSTALLED_APPS += ["apis_core.documentation"]
-INSTALLED_APPS.insert(0, "apis_core.relations")
 INSTALLED_APPS.insert(0, "apis_core.collections")
 INSTALLED_APPS += ["apis_acdhch_django_invite"]
 INSTALLED_APPS += ["django_json_editor_field"]


### PR DESCRIPTION
Its part of the default settings now
