### PR TITLE
chore(gitignore): ignore *.mo files, as they are autogenerated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.sqlite3
 local
 .env
+.mo


### PR DESCRIPTION
[skip ci]
